### PR TITLE
Use laravel base controller in stead of app controller

### DIFF
--- a/src/Http/Controllers/LaravelExactOnlineController.php
+++ b/src/Http/Controllers/LaravelExactOnlineController.php
@@ -2,7 +2,7 @@
 
 namespace PendoNL\LaravelExactOnline\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use PendoNL\LaravelExactOnline\LaravelExactOnline;
 
 class LaravelExactOnlineController extends Controller


### PR DESCRIPTION
Hi

Found your packages today in my search for an exact online wrapper for laravel. I see there's a notice above it saying it shouldn't be used in production. After checking the code I don't see a whole lot that could go wrong right? What would you consider the steps for it to become production ready?

I ran into a small issue. I use the laravel lucid architecture (https://github.com/lucid-architecture/laravel) and don't have a `App\Http\Controllers\Controller` class (it's namespaced differently). Here's a pull request to just inherit the laravel base controller.