### PR TITLE
Add additional catch to to prevent the use of old refresh tokens

### DIFF
--- a/src/LaravelExactOnlineFacade.php
+++ b/src/LaravelExactOnlineFacade.php
@@ -11,7 +11,7 @@ class LaravelExactOnlineFacade extends Facade
      *
      * @return string
      */
-    public static function getFacadeAccessor()
+    protected static function getFacadeAccessor()
     {
         return 'laravel-exact-online';
     }

--- a/src/Providers/LaravelExactOnlineServiceProvider.php
+++ b/src/Providers/LaravelExactOnlineServiceProvider.php
@@ -3,7 +3,6 @@
 namespace PendoNL\LaravelExactOnline\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Facades\Auth;
 use PendoNL\LaravelExactOnline\LaravelExactOnline;
 
 class LaravelExactOnlineServiceProvider extends ServiceProvider
@@ -35,8 +34,7 @@ class LaravelExactOnlineServiceProvider extends ServiceProvider
     {
         $this->app->alias(LaravelExactOnline::class, 'laravel-exact-online');
 
-        $this->app->singleton('Exact\Connection', function() {
-
+        $this->app->singleton('Exact\Connection', function () {
             $config = LaravelExactOnline::loadConfig();
 
             $connection = new \Picqer\Financials\Exact\Connection();
@@ -44,31 +42,36 @@ class LaravelExactOnlineServiceProvider extends ServiceProvider
             $connection->setExactClientId(config('laravel-exact-online.exact_client_id'));
             $connection->setExactClientSecret(config('laravel-exact-online.exact_client_secret'));
             $connection->setBaseUrl('https://start.exactonline.' . config('laravel-exact-online.exact_country_code'));
-            if(config('laravel-exact-online.exact_division') !== '') {
+
+            if (config('laravel-exact-online.exact_division') !== '') {
                 $connection->setDivision(config('laravel-exact-online.exact_division'));
             }
 
-            if(isset($config->exact_authorisationCode)) {
+            if (isset($config->exact_authorisationCode)) {
                 $connection->setAuthorizationCode($config->exact_authorisationCode);
             }
-            if(isset($config->exact_accessToken)) {
+
+            if (isset($config->exact_accessToken)) {
                 $connection->setAccessToken(unserialize($config->exact_accessToken));
             }
-            if(isset($config->exact_refreshToken)) {
+
+            if (isset($config->exact_refreshToken)) {
                 $connection->setRefreshToken($config->exact_refreshToken);
             }
-            if(isset($config->exact_tokenExpires)) {
+
+            if (isset($config->exact_tokenExpires)) {
                 $connection->setTokenExpires($config->exact_tokenExpires);
             }
 
             try {
-
-                if(isset($config->exact_authorisationCode)) {
+                if (isset($config->exact_authorisationCode)) {
                     $connection->connect();
                 }
-
-            } catch (\Exception $e)
-            {
+            } catch (\GuzzleHttp\Exception\RequestException $e) {
+                $connection->setAccessToken(null);
+                $connection->setRefreshToken(null);
+                $connection->connect();
+            } catch (\Exception $e) {
                 throw new \Exception('Could not connect to Exact: ' . $e->getMessage());
             }
 


### PR DESCRIPTION
Exact Online is going to deactivate the possibility to reuse old refresh tokens. On October 16 Exact Online has the possibility to reuse old refresh tokens, as planned, deactivated. A large number of applications did not implement a routine for this behaviour so they re-enabled it again.

The addition of the catch makes sure a refresh token can not be reused again in the same cycle.

When there is no AccessToken **AND** no RefreshToken the `connect()` function
will run inside the following statement :

```php
// If access token is not set or token has expired, acquire new token
if (empty($this->accessToken) || $this->tokenHasExpired()) {
    $this->acquireAccessToken();
}